### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,8 @@ jobs:
   pre-commit:
     name: Format
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       - name: Install uv


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/optional_dependencies/security/code-scanning/5](https://github.com/GalacticDynamics/optional_dependencies/security/code-scanning/5)

To fix the issue, you should set explicit permissions for the GITHUB_TOKEN either at the workflow root level or per job. For this case, since the flagged job is `pre-commit`, and it only needs read access, you can add a `permissions` block under that job. The minimal set would be `contents: read`, preventing write access while allowing code checkout and local analysis. No functionality will change; rather, it will make the workflow more secure.

Edit `.github/workflows/ci.yml`; under the `pre-commit` job (after `runs-on: ubuntu-latest`), insert the explicit permissions block:

```yaml
permissions:
  contents: read
```

No imports or extra methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
