### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
   status:
     name: CI Pass
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [format, tests]
     if: always()
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/optional_dependencies/security/code-scanning/6](https://github.com/GalacticDynamics/optional_dependencies/security/code-scanning/6)

In general, to fix this problem you add an explicit `permissions` block either at the workflow root (applies to all jobs that do not override it) or on the specific job. The block should grant only the scopes that job actually needs; for a status/aggregation job that only reads workflow metadata, `permissions: contents: read` (or even `permissions: {}` if no token use is needed) is typically sufficient.

For this workflow, the existing `format` and `tests` jobs already declare `permissions: contents: read`. The missing restriction is only in the `status` job, starting at line 65. To avoid changing behavior elsewhere, the best fix is to add a `permissions` block to that job alone. There is no evidence that `status` needs write access or any special scopes; it only runs `re-actors/alls-green`, which checks `needs` results. A minimal, consistent choice is:

```yaml
permissions:
  contents: read
```

placed directly under `runs-on:` in the `status` job. No imports or other code changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
